### PR TITLE
rebrand: KoalaOps → Skyhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Apply kustomize overlays to Kubernetes clusters with robust metadata extraction 
 ```yaml
 # Typical usage with kustomize-inspect
 - name: Inspect overlay
-  uses: KoalaOps/kustomize-inspect@v1
+  uses: skyhook-io/kustomize-inspect@v1
   id: inspect
   with:
     overlay_dir: deploy/overlays/production
 
 - name: Apply to cluster
-  uses: KoalaOps/kustomize-apply@v1
+  uses: skyhook-io/kustomize-apply@v1
   with:
     overlay_dir: deploy/overlays/production
     namespace: ${{ steps.inspect.outputs.namespace }}
@@ -53,20 +53,20 @@ Apply kustomize overlays to Kubernetes clusters with robust metadata extraction 
 ### Basic deployment with inspect
 ```yaml
 - name: Edit kustomization
-  uses: KoalaOps/kustomize-edit@v1
+  uses: skyhook-io/kustomize-edit@v1
   with:
     overlay_dir: deploy/overlays/staging
     image: backend
     tag: v1.2.3
 
 - name: Inspect changes
-  uses: KoalaOps/kustomize-inspect@v1
+  uses: skyhook-io/kustomize-inspect@v1
   id: inspect
   with:
     overlay_dir: deploy/overlays/staging
 
 - name: Apply to cluster
-  uses: KoalaOps/kustomize-apply@v1
+  uses: skyhook-io/kustomize-apply@v1
   with:
     overlay_dir: deploy/overlays/staging
     namespace: ${{ steps.inspect.outputs.namespace }}
@@ -76,13 +76,13 @@ Apply kustomize overlays to Kubernetes clusters with robust metadata extraction 
 ### Dry run first
 ```yaml
 - name: Inspect
-  uses: KoalaOps/kustomize-inspect@v1
+  uses: skyhook-io/kustomize-inspect@v1
   id: inspect
   with:
     overlay_dir: deploy/overlays/production
 
 - name: Preview changes
-  uses: KoalaOps/kustomize-apply@v1
+  uses: skyhook-io/kustomize-apply@v1
   with:
     overlay_dir: deploy/overlays/production
     namespace: ${{ steps.inspect.outputs.namespace }}
@@ -90,7 +90,7 @@ Apply kustomize overlays to Kubernetes clusters with robust metadata extraction 
 
 - name: Apply if approved
   if: ${{ inputs.approved == 'true' }}
-  uses: KoalaOps/kustomize-apply@v1
+  uses: skyhook-io/kustomize-apply@v1
   with:
     overlay_dir: deploy/overlays/production
     namespace: ${{ steps.inspect.outputs.namespace }}
@@ -100,7 +100,7 @@ Apply kustomize overlays to Kubernetes clusters with robust metadata extraction 
 ### No wait (fire and forget)
 ```yaml
 - name: Quick apply
-  uses: KoalaOps/kustomize-apply@v1
+  uses: skyhook-io/kustomize-apply@v1
   with:
     overlay_dir: deploy/overlays/dev
     namespace: development
@@ -110,7 +110,7 @@ Apply kustomize overlays to Kubernetes clusters with robust metadata extraction 
 ### Server-side apply
 ```yaml
 - name: Apply with SSA
-  uses: KoalaOps/kustomize-apply@v1
+  uses: skyhook-io/kustomize-apply@v1
   with:
     overlay_dir: deploy/overlays/production
     namespace: ${{ steps.inspect.outputs.namespace }}
@@ -127,14 +127,14 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Login to cloud
-        uses: KoalaOps/cloud-login@v1
+        uses: skyhook-io/cloud-login@v1
         with:
           provider: aws
           region: us-east-1
           cluster: production
       
       - name: Update kustomization
-        uses: KoalaOps/kustomize-edit@v1
+        uses: skyhook-io/kustomize-edit@v1
         with:
           overlay_dir: deploy/overlays/production
           image: backend
@@ -144,13 +144,13 @@ jobs:
             deployment-id:${{ github.run_id }}
       
       - name: Inspect changes
-        uses: KoalaOps/kustomize-inspect@v1
+        uses: skyhook-io/kustomize-inspect@v1
         id: inspect
         with:
           overlay_dir: deploy/overlays/production
       
       - name: Apply to cluster
-        uses: KoalaOps/kustomize-apply@v1
+        uses: skyhook-io/kustomize-apply@v1
         with:
           overlay_dir: deploy/overlays/production
           namespace: ${{ steps.inspect.outputs.namespace }}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: 'Kustomize Apply'
 description: 'Apply a built kustomize overlay to a Kubernetes cluster; waits only on workloads provided by Inspect'
-author: 'KoalaOps'
+author: 'Skyhook'
 
 branding:
   icon: 'upload-cloud'


### PR DESCRIPTION
## Summary
Update all references from KoalaOps to Skyhook as part of the rebranding initiative.

## Changes
- Organization: `KoalaOps` → `skyhook-io`
- Author: `KoalaOps` → `Skyhook`
- Product name: `Koala` → `Skyhook` (where applicable)
- All usage examples updated to reference `skyhook-io/*`
- All documentation and URLs updated

## Notes
- This PR should be merged before transferring the repository to the skyhook-io organization
- After transfer, GitHub will automatically redirect old URLs to new ones